### PR TITLE
[MRG] caffe install on aws image

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -1,0 +1,84 @@
+## Refer to http://caffe.berkeleyvision.org/installation.html
+# Contributions simplifying and improving our build system are welcome!
+
+# cuDNN acceleration switch (uncomment to build with cuDNN).
+# USE_CUDNN := 1
+
+# CPU-only switch (uncomment to build without GPU support).
+# CPU_ONLY := 1
+
+# To customize your choice of compiler, uncomment and set the following.
+# N.B. the default for Linux is g++ and the default for OSX is clang++
+# CUSTOM_CXX := g++
+
+# CUDA directory contains bin/ and lib/ directories that we need.
+CUDA_DIR := /usr/local/cuda
+# On Ubuntu 14.04, if cuda tools are installed via
+# "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
+# CUDA_DIR := /usr
+
+# CUDA architecture setting: going with all of them.
+# For CUDA < 6.0, comment the *_50 lines for compatibility.
+CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
+		-gencode arch=compute_20,code=sm_21 \
+		-gencode arch=compute_30,code=sm_30 \
+		-gencode arch=compute_35,code=sm_35 \
+		-gencode arch=compute_50,code=sm_50 \
+		-gencode arch=compute_50,code=compute_50
+
+# BLAS choice:
+# atlas for ATLAS (default)
+# mkl for MKL
+# open for OpenBlas
+BLAS := open
+# Custom (MKL/ATLAS/OpenBLAS) include and lib directories.
+# Leave commented to accept the defaults for your choice of BLAS
+# (which should work)!
+BLAS_INCLUDE := /home/ubuntu/OpenBLAS
+BLAS_LIB := /home/ubuntu/OpenBLAS
+
+# This is required only if you will compile the matlab interface.
+# MATLAB directory should contain the mex binary in /bin.
+# MATLAB_DIR := /usr/local
+# MATLAB_DIR := /Applications/MATLAB_R2012b.app
+
+# NOTE: this is required only if you will compile the python interface.
+# We need to be able to find Python.h and numpy/arrayobject.h.
+# PYTHON_INCLUDE := /usr/include/python2.7 \
+# 		/usr/lib/python2.7/dist-packages/numpy/core/include
+PYTHON_INCLUDE := /home/ubuntu/venv/include/python2.7/ \
+	       /home/ubuntu/venv/local/lib/python2.7/site-packages/numpy/core/include/
+# Anaconda Python distribution is quite popular. Include path:
+# Verify anaconda location, sometimes it's in root.
+# ANACONDA_HOME := $(HOME)/anaconda
+# PYTHON_INCLUDE := $(ANACONDA_HOME)/include \
+		# $(ANACONDA_HOME)/include/python2.7 \
+		# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include \
+
+# We need to be able to find libpythonX.X.so or .dylib.
+PYTHON_LIB := /usr/lib
+# PYTHON_LIB := $(ANACONDA_HOME)/lib
+
+# Uncomment to support layers written in Python (will link against Python libs)
+# WITH_PYTHON_LAYER := 1
+
+# Whatever else you find you need goes here.
+INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include
+LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib
+
+# Uncomment to use `pkg-config` to specify OpenCV library paths.
+# (Usually not necessary -- OpenCV libraries are normally installed in one of the above $LIBRARY_DIRS.)
+# USE_PKG_CONFIG := 1
+
+BUILD_DIR := build
+DISTRIBUTE_DIR := distribute
+
+# Uncomment for debugging. Does not work on OSX due to https://github.com/BVLC/caffe/issues/171
+# DEBUG := 1
+
+# The ID of the GPU that 'make runtest' will use to run unit tests.
+TEST_GPUID := 0
+
+# enable pretty build (comment to see full commands)
+Q ?= @
+

--- a/install_caffe.sh
+++ b/install_caffe.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+git clone https://github.com/BVLC/caffe.git
+
+# git clone https://github.com/scikit-image/scikit-image.git
+# cd scikit-image
+# python setup.py install
+
+pip install pillow networkx
+pip install scikit-image
+
+sudo apt-get install protobuf-compiler
+
+sudo apt-get install libboost-all-dev
+
+sudo apt-get install libgflags-dev
+
+sudo apt-get install libgoogle-glog-dev
+
+sudo apt-get install libhdf5-serial-dev
+
+sudo apt-get install libleveldb-dev
+
+sudo apt-get install liblmdb-dev
+
+sudo apt-get install libsnappy-dev
+
+sudo apt-get install libdc1394-22-dev
+
+cd caffe/python
+pip install -r requirements.txt

--- a/install_caffe.sh
+++ b/install_caffe.sh
@@ -14,3 +14,5 @@ cd python
 pip install networkx -U
 pip install pillow -U
 pip install -r requirements.txt
+
+ln -s /home/ubuntu/caffe/python/caffe /home/ubuntu/venv/lib/python2.7/site-packages/caffe

--- a/install_caffe.sh
+++ b/install_caffe.sh
@@ -1,31 +1,16 @@
 #!/bin/bash
 
-git clone https://github.com/BVLC/caffe.git
+sudo apt-get install protobuf-compiler libboost-all-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev libleveldb-dev liblmdb-dev libsnappy-dev libopencv-dev libyaml-dev
 
-# git clone https://github.com/scikit-image/scikit-image.git
-# cd scikit-image
-# python setup.py install
+git clone https://github.com/BVLC/caffe.git ../caffe
 
-pip install pillow networkx
-pip install scikit-image
+cp Makefile.config.example ../caffe/Makefile.config
 
-sudo apt-get install protobuf-compiler
+cd ../caffe
+make all
+make pycaffe
 
-sudo apt-get install libboost-all-dev
-
-sudo apt-get install libgflags-dev
-
-sudo apt-get install libgoogle-glog-dev
-
-sudo apt-get install libhdf5-serial-dev
-
-sudo apt-get install libleveldb-dev
-
-sudo apt-get install liblmdb-dev
-
-sudo apt-get install libsnappy-dev
-
-sudo apt-get install libdc1394-22-dev
-
-cd caffe/python
+cd python
+pip install networkx -U
+pip install pillow -U
 pip install -r requirements.txt


### PR DESCRIPTION
What the title says. The script `install_caffe.sh` does it.

Two points still need addressing:
- `apt-get install` asks for permission to install stuff (one has to type 'y'). I guess one can override this.
- Right now, I do `cp Makefile.config.example $CAFFE_DIR/Makefile.config` in order to write in our config. @ogrisel you said this may be better done with a patch. That way the rest of the file can change and we will see those changes. How is this best done?
